### PR TITLE
[nos3#264] GSW Switch

### DIFF
--- a/gsw/GENERIC_EPS/lib/slope_intercept_conversion.rb
+++ b/gsw/GENERIC_EPS/lib/slope_intercept_conversion.rb
@@ -1,6 +1,6 @@
-require 'openc3/conversions/conversion'
+require 'cosmos/conversions/conversion'
 
-module OpenC3
+module Cosmos
   class SlopeInterceptConversion < Conversion
     def initialize(packet_field, slope, intercept=0)
       super()


### PR DESCRIPTION
# OpenC3 to COSMOS
This happened across `./components/*/gsw/*` and `./gsw/cosmos/*`
* openc3/conversions/conversion
  - cosmos/conversions/conversion
* module OpenC3
  - module Cosmos
